### PR TITLE
Allow passing openssl.ssl.context:setCipherList a vararg of ciphers, or an array

### DIFF
--- a/doc/luaossl.tex
+++ b/doc/luaossl.tex
@@ -871,9 +871,9 @@ Sets the X.509 certificate \module{openssl.x509} object $crt$ to send during SSL
 
 Sets the private key \module{openssl.pkey} object $key$ for use during SSL connection instance handshakes.
 
-\subsubsection[\fn{context:setCipherList}]{\fn{context:setCipherList($string$)}}
+\subsubsection[\fn{context:setCipherList}]{\fn{context:setCipherList($string$ [, ...])}}
 
-Sets the allowed public key and private key algorithms. The string format is documented in the \href{http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT}{OpenSSL ciphers(1) utility documentation}.
+Sets the allowed public key and private key algorithm(s). The string format is documented in the \href{http://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT}{OpenSSL ciphers(1) utility documentation}.
 
 \subsubsection[\fn{context:setEphemeralKey}]{\fn{context:setEphemeralKey($key$)}}
 

--- a/src/openssl.ssl.context.lua
+++ b/src/openssl.ssl.context.lua
@@ -5,7 +5,7 @@ local pack = table.pack or function(...) return { n = select("#", ...); ... } en
 -- Allow passing a vararg of ciphers, or an array
 local setCipherList; setCipherList = ctx.interpose("setCipherList", function (self, ciphers, ...)
 	if (...) then
-		local ciphers_t = pack(...)
+		local ciphers_t = pack(ciphers, ...)
 		ciphers = table.concat(ciphers_t, ":", 1, ciphers_t.n)
 	elseif type(ciphers) == "table" then
 		ciphers = table.concat(ciphers, ":")

--- a/src/openssl.ssl.context.lua
+++ b/src/openssl.ssl.context.lua
@@ -1,3 +1,16 @@
 local ctx = require"_openssl.ssl.context"
 
+local pack = table.pack or function(...) return { n = select("#", ...); ... } end
+
+-- Allow passing a vararg of ciphers, or an array
+local setCipherList; setCipherList = ctx.interpose("setCipherList", function (self, ciphers, ...)
+	if (...) then
+		local ciphers_t = pack(...)
+		ciphers = table.concat(ciphers_t, ":", 1, ciphers_t.n)
+	elseif type(ciphers) == "table" then
+		ciphers = table.concat(ciphers, ":")
+	end
+	return setCipherList(self, ciphers)
+end)
+
 return ctx


### PR DESCRIPTION
Fixes #13