### PR TITLE
bignum: Add initialisers from hex and binary

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -29,7 +29,7 @@
 #include <strings.h>      /* strcasecmp(3) */
 #include <math.h>         /* INFINITY fabs(3) floor(3) frexp(3) fmod(3) round(3) isfinite(3) */
 #include <time.h>         /* struct tm time_t strptime(3) time(2) */
-#include <ctype.h>        /* tolower(3) */
+#include <ctype.h>        /* isdigit(3), isxdigit(3), tolower(3) */
 #include <errno.h>        /* ENOMEM ENOTSUP EOVERFLOW errno */
 #include <assert.h>       /* assert */
 
@@ -1685,7 +1685,7 @@ static _Bool f2bn(BIGNUM **bn, double f) {
 static BIGNUM *(checkbig)(lua_State *L, int index, _Bool *lvalue) {
 	BIGNUM **bn;
 	const char *str;
-	size_t len;
+	size_t len, i;
 	_Bool neg, hex = 0;
 
 	index = lua_absindex(L, index);
@@ -1702,6 +1702,15 @@ static BIGNUM *(checkbig)(lua_State *L, int index, _Bool *lvalue) {
 
 		if (str[neg] == '0' && (str[neg+1] == 'x' || str[neg+1] == 'X')) {
 			hex = 1;
+			for (i = 2+neg; i < len; i++) {
+				if (!isxdigit(str[i]))
+					luaL_argerror(L, 1, "invalid hex string");
+			}
+		} else {
+			for (i = neg; i < len; i++) {
+				if (!isdigit(str[i]))
+					luaL_argerror(L, 1, "invalid decimal string");
+			}
 		}
 
 		bn = prepsimple(L, BIGNUM_CLASS);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1686,7 +1686,7 @@ static BIGNUM *(checkbig)(lua_State *L, int index, _Bool *lvalue) {
 	BIGNUM **bn;
 	const char *str;
 	size_t len, i;
-	_Bool neg, hex = 0;
+	_Bool neg, hex;
 
 	index = lua_absindex(L, index);
 
@@ -1696,17 +1696,17 @@ static BIGNUM *(checkbig)(lua_State *L, int index, _Bool *lvalue) {
 
 		str = lua_tolstring(L, index, &len);
 
-		luaL_argcheck(L, len > 0 && *str, index, "invalid big number string");
-
 		neg = (str[0] == '-');
+		hex = (str[neg] == '0' && (str[neg+1] == 'x' || str[neg+1] == 'X'));
 
-		if (str[neg] == '0' && (str[neg+1] == 'x' || str[neg+1] == 'X')) {
-			hex = 1;
+		if (hex) {
+			luaL_argcheck(L, len > 2+(size_t)neg, index, "invalid hex string");
 			for (i = 2+neg; i < len; i++) {
 				if (!isxdigit(str[i]))
 					luaL_argerror(L, 1, "invalid hex string");
 			}
 		} else {
+			luaL_argcheck(L, len > neg, index, "invalid decimal string");
 			for (i = neg; i < len; i++) {
 				if (!isdigit(str[i]))
 					luaL_argerror(L, 1, "invalid decimal string");

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1598,6 +1598,17 @@ static int bn_new(lua_State *L) {
 } /* bn_new() */
 
 
+static int bn_fromBinary(lua_State *L) {
+	size_t len;
+	const char *s = luaL_checklstring(L, 1, &len);
+	BIGNUM *bn = bn_push(L);
+	if (!BN_bin2bn((const unsigned char*)s, len, bn)) {
+		auxL_error(L, auxL_EOPENSSL, "bignum");
+	}
+	return 1;
+} /* bn_fromBinary() */
+
+
 static int bn_interpose(lua_State *L) {
 	return interpose(L, BIGNUM_CLASS);
 } /* bn_interpose() */
@@ -2119,6 +2130,7 @@ static const luaL_Reg bn_metatable[] = {
 static const luaL_Reg bn_globals[] = {
 	{ "new",           &bn_new },
 	{ "interpose",     &bn_interpose },
+	{ "fromBinary",    &bn_fromBinary },
 	{ "generatePrime", &bn_generatePrime },
 	{ NULL,            NULL },
 };

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1673,7 +1673,7 @@ static _Bool f2bn(BIGNUM **bn, double f) {
 
 static BIGNUM *(checkbig)(lua_State *L, int index, _Bool *lvalue) {
 	BIGNUM **bn;
-	const char *dec;
+	const char *str;
 	size_t len;
 
 	index = lua_absindex(L, index);
@@ -1682,14 +1682,19 @@ static BIGNUM *(checkbig)(lua_State *L, int index, _Bool *lvalue) {
 	case LUA_TSTRING:
 		*lvalue = 0;
 
-		dec = lua_tolstring(L, index, &len);
+		str = lua_tolstring(L, index, &len);
 
-		luaL_argcheck(L, len > 0 && *dec, index, "invalid big number string");
+		luaL_argcheck(L, len > 0 && *str, index, "invalid big number string");
 
 		bn = prepsimple(L, BIGNUM_CLASS);
 
-		if (!BN_dec2bn(bn, dec))
-			auxL_error(L, auxL_EOPENSSL, "bignum");
+		if (str[0] == '0' && (str[1] == 'x' || str[1] == 'X')) {
+			if (!BN_hex2bn(bn, str+2))
+				auxL_error(L, auxL_EOPENSSL, "bignum");
+		} else {
+			if (!BN_dec2bn(bn, str))
+				auxL_error(L, auxL_EOPENSSL, "bignum");
+		}
 
 		lua_replace(L, index);
 


### PR DESCRIPTION
If a string passed to a bignum function starts with '0x' (or 0X) interpret it as hex.

Validate strings passed to `checkbig`

Add a new constructor `fromBinary` (Fixes #44)