### PR TITLE
Expose openssl.x509.csr

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -96,6 +96,7 @@ MODS$(1)_$(d) = \
 	$$(DESTDIR)$(3)/openssl/x509/altname.lua \
 	$$(DESTDIR)$(3)/openssl/x509/chain.lua \
 	$$(DESTDIR)$(3)/openssl/x509/crl.lua \
+	$$(DESTDIR)$(3)/openssl/x509/csr.lua \
 	$$(DESTDIR)$(3)/openssl/x509/extension.lua \
 	$$(DESTDIR)$(3)/openssl/x509/store.lua \
 	$$(DESTDIR)$(3)/openssl/pkcs12.lua \

--- a/src/openssl.x509.csr.lua
+++ b/src/openssl.x509.csr.lua
@@ -1,0 +1,1 @@
+return require('_openssl.x509.csr')


### PR DESCRIPTION
openssl.x509.csr is documented but not exposed, so accessing it requires you to `require"_openssl.x509.csr"`.