### PR TITLE
Add support for getting or setting SubjectAltNames on a CSR

### DIFF
--- a/doc/luaossl.tex
+++ b/doc/luaossl.tex
@@ -597,6 +597,14 @@ Returns the subject distinguished name as an \module{x509.name} object.
 
 Sets the subject distinguished name. $name$ should be an \module{x509.name} object.
 
+\subsubsection[\fn{csr:getSubjectAlt}]{\fn{csr:getSubjectAlt()}}
+
+Returns the subject alternative name as an \module{x509.altname} object.
+
+\subsubsection[\fn{csr:setSubjectAlt}]{\fn{csr:setSubjectAlt($name$)}}
+
+Sets the subject alternative names. $name$ should be an \module{x509.altname} object.
+
 \subsubsection[\fn{csr:getPublicKey}]{\fn{csr:getPublicKey()}}
 
 Returns the public key component as an \module{openssl.pkey} object.

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4328,6 +4328,7 @@ static const auxL_IntegerReg xe_textopts[] = {
 	{ "ERROR_UNKNOWN", X509V3_EXT_ERROR_UNKNOWN },
 	{ "PARSE_UNKNOWN", X509V3_EXT_PARSE_UNKNOWN },
 	{ "DUMP_UNKNOWN", X509V3_EXT_DUMP_UNKNOWN },
+	{ NULL, 0 },
 };
 
 int luaopen__openssl_x509_extension(lua_State *L) {


### PR DESCRIPTION
Tested with the following lua script below and this command:

```bash
lua test.lua && \
  openssl req -noout -text -in modified.csr  \| grep -A1 'Subject Alternative Name' && \
  openssl req -noout -text -in empty.csr  | grep -A1 'Subject Alternative Name'
```


```lua
local pkey = require "openssl.pkey"
local x509_csr = require"_openssl.x509.csr"
local x509_altname = require"openssl.x509.altname"
local x509_name = require"openssl.x509.name"

key = pkey.new({ bits = 4096 })

data = [[
-----BEGIN CERTIFICATE REQUEST-----
MIIFQjCCAyoCAQAwUzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk1OMRQwEgYDVQQH
DAtNaW5uZWFwb2xpczEhMB8GA1UECwwYRG9tYWluIENvbnRyb2wgVmFsaWRhdGVk
MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA4sXzE3GQtpFKiuGe389k
MB0OaGXQxiI/yl6zm9PyYWe5aMpx1THDVhkWXemDVkduEqtLfa8GSNT0ps3BPdTx
qxNwZ3J9xiVfNZZYO5ZSxs1g32M1lw20wIezLpbQ1ggyt01o9VTQDY6kA+D0G87B
4FtIZxVaXM2z5HVaGYyivxAygDukDsO+RU0NC9mYOfAP4rt/u/xp8LsW0b4aIFqx
gPcBZj92B+Wi2B4sKSe1m5kMfmh+e8v981hbY7V8FUMebB63iRGF6GU4kjXiMMW6
gSoc+usq9li8VxjxPngql9pyLqFIa/2gW0c9sKKB2X9tB0nmudjAUrjZjHZEDlNr
yx15JHhEIT31yP9xGQpy5H+jBldp/shqaV4Alsou9Hn9W71ap7VHOWLrIcaZGKTn
CVSSYPygn4Rm8Cgwbv5mP6G+SqGHAFqirEysAARUFxsjBLlkNaVFOA38l2cufH8n
1NE/B4iOG/ETvQDR/aKrbyKKo2k/hO941h3J9pwJcCikE0NsRcH6WAm8ifJ0Zd/q
u8fqI8g9mYPbMWy11+njnfNOVFVhNOmM1/ZM66ac9zgGYncaHu4UzYnvWw75tDbF
vA+oIJlcxBUtWeTcYRf4xEcRL8IcHEwh1BZq7bgP42Wu+0aBuaa3eYXNBApCNP39
QmnHlo0iGH2rVeOfcq/wULcCAwEAAaCBqTCBpgYJKoZIhvcNAQkOMYGYMIGVMAkG
A1UdEwQCMAAwCwYDVR0PBAQDAgXgMHsGA1UdEQR0MHKCE3NlcnZlcjEuZXhhbXBs
ZS5jb22CEG1haWwuZXhhbXBsZS5jb22CD3d3dy5leGFtcGxlLmNvbYITd3d3LnN1
Yi5leGFtcGxlLmNvbYIObXguZXhhbXBsZS5jb22CE3N1cHBvcnQuZXhhbXBsZS5j
b20wDQYJKoZIhvcNAQEFBQADggIBAMiFPtDKVsy4HBhVkHSnbbIl41baaGGFjI/O
MG8fI7P9jplq5rNZcLxSW2zLzMVuYzCoC+q5roRE5zVVyJlB+5dY0A8e2xKaWVOT
AB9WvgepPvXDoGNViMBoX/idj3J2BU3e/cX08QWRPjKigwQWQWvUGsZYitGJv+Yv
/LbIDlxr8Jr+1Txcm1EdXcff6Owlh6Nu59bgCMRdZvABmWfU5ULmUDTJnmc3P9St
onz07v8ku8/XL7wwOfLJWVSVOk7RONySIJiPfVkgrU3YWiT64JaluDbFEIwnEgJS
04xL6Pl66bADXCaeG3pZ8ypCs41+4bqFvCnOYma0Sk8fv8hSCWvJfMQI+nQslPJu
UuGK4C4EEnYvoh/Qs/XEshfrVaNcG0zER3XtsRPAjhZjTPTcRgEjpOI0w3TJAvlN
LSQV4mXN6E2bcU+cRYvNSgqITwJ7c6wpsONwApIQwFryLsFSCHaIdSLpAZbEPNEW
UPa3uWXk5lWrBBPPkxyPbt8D3zpzahY4ycYEFKdz8MLdgA7pDalI2XpwgmoUybkw
AJnsFg7fnFc03R4FsqxCqvbRYj3Bccb8Uhg1zTeXU+7nxjP2yYdT+In16L9SYOsU
4ozEPqnGY9aI11i6C7hBwrUTvHYD6ZSDlylsUXKw/VZXQvS3+C0h6NuRmjBx8jNU
RG1EyxL4
-----END CERTIFICATE REQUEST-----]]
--
csr = x509_csr.new(data)

print ("  Old altnames", csr:getSubjectAlt())

gn = x509_altname.new()
gn:add("DNS", "foo.com")
gn:add("DNS", "*.foo.com")

csr:setSubjectAlt(gn)
csr:setPublicKey(key)
csr:sign(key)

print ("  New altnames", csr:getSubjectAlt())
f, err = io.open("modified.csr", "w")
if (err) then
  error(err)
end
f:write(tostring(csr))

csr = x509_csr.new()

local name = x509_name.new()
name:add("CN", "example.com")
csr:setSubject(name)
csr:setSubjectAlt(gn)
csr:setPublicKey(key)
csr:sign(key)

print ("Empty altnames", csr:getSubjectAlt())
f, err = io.open("empty.csr", "w")
if (err) then
  error(err)
end
f:write(tostring(csr))

```