### PR TITLE
Add rockspec file for installing from the repo directly

### DIFF
--- a/luaossl-github-0.rockspec
+++ b/luaossl-github-0.rockspec
@@ -1,0 +1,72 @@
+package = "luaossl"
+version = "github-0"
+source = {
+        url = "git://github.com/wahern/luaossl.git"
+}
+description = {
+	summary = "Most comprehensive OpenSSL module in the Lua universe.";
+	homepage = "http://25thandclement.com/~william/projects/luaossl.html";
+	license = "MIT/X11";
+}
+supported_platforms = {
+	"unix";
+}
+dependencies = {
+	"lua >= 5.1";
+}
+external_dependencies = {
+	OPENSSL = {
+		header = "openssl/ssl.h";
+		library = "ssl";
+	};
+	CRYPTO = {
+		header = "openssl/hmac.h"; -- Picked one of the many header files
+		library = "crypto";
+	};
+}
+build = {
+	type = "builtin";
+	modules = {
+		["_openssl"] = {
+			sources = { "src/openssl.c"; };
+			libraries = {
+				"ssl"; "crypto";
+				"pthread";
+				"dl";
+				"m";
+			};
+			defines = {
+				"_REENTRANT"; "_THREAD_SAFE";
+				"_GNU_SOURCE";
+				"LUA_COMPAT_APIINTCASTS";
+			};
+			incdirs = {
+				"$(OPENSSL_INCDIR)";
+				"$(CRYPTO_INCDIR)";
+			};
+			libdirs = {
+				"$(OPENSSL_LIBDIR)";
+				"$(CRYPTO_LIBDIR)";
+			};
+		};
+		["openssl"] = "src/openssl.lua";
+		["openssl.auxlib"] = "src/openssl.auxlib.lua";
+		["openssl.bignum"] = "src/openssl.bignum.lua";
+		["openssl.cipher"] = "src/openssl.cipher.lua";
+		["openssl.digest"] = "src/openssl.digest.lua";
+		["openssl.hmac"] = "src/openssl.hmac.lua";
+		["openssl.pkcs12"] = "src/openssl.pkcs12.lua";
+		["openssl.pkey"] = "src/openssl.pkey.lua";
+		["openssl.pubkey"] = "src/openssl.pubkey.lua";
+		["openssl.rand"] = "src/openssl.rand.lua";
+		["openssl.ssl.context"] = "src/openssl.ssl.context.lua";
+		["openssl.ssl"] = "src/openssl.ssl.lua";
+		["openssl.x509"] = "src/openssl.x509.lua";
+		["openssl.x509.altname"] = "src/openssl.x509.altname.lua";
+		["openssl.x509.chain"] = "src/openssl.x509.chain.lua";
+		["openssl.x509.crl"] = "src/openssl.x509.crl.lua";
+		["openssl.x509.extension"] = "src/openssl.x509.extension.lua";
+		["openssl.x509.name"] = "src/openssl.x509.name.lua";
+		["openssl.x509.store"] = "src/openssl.x509.store.lua";
+	}
+}


### PR DESCRIPTION
I needed master rather than the version on luarocks to fix this issue :

https://github.com/wahern/luaossl/issues/53

Seemed easier to make the existing rockspec file work with the repo rather than figure out the build system
