### PR TITLE
Use arc4random()/getrandom() to get random bytes instead of sysctl() interface

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -7844,7 +7844,7 @@ static int randL_stir(struct randL_state *st, unsigned rqstd) {
 
 		arc4random(data, n);
 
-		RAND_add(data, n, n);
+		RAND_seed(data, n);
 
 		count += n;
 	}
@@ -7858,7 +7858,7 @@ static int randL_stir(struct randL_state *st, unsigned rqstd) {
 			break;
 		}
 
-		RAND_add(data, n, n);
+		RAND_seed(data, n);
 
 		count += n;
 	}
@@ -7871,7 +7871,7 @@ static int randL_stir(struct randL_state *st, unsigned rqstd) {
 		if (0 != sysctl(mib, countof(mib), data, &n, (void *)0, 0))
 			break;
 
-		RAND_add(data, n, n);
+		RAND_seed(data, n);
 
 		count += n;
 	}
@@ -7906,7 +7906,7 @@ static int randL_stir(struct randL_state *st, unsigned rqstd) {
 
 				goto error;
 			default:
-				RAND_add(data, n, n);
+				RAND_seed(data, n);
 
 				count += n;
 			}

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -59,6 +59,7 @@
 #include <linux/version.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 #define HAVE_GETRANDOM
+#include <sys/syscall.h>
 #include <linux/random.h>
 #else
 #define HAVE_SYS_SYSCTL_H
@@ -7852,7 +7853,7 @@ static int randL_stir(struct randL_state *st, unsigned rqstd) {
 	while (count < rqstd) {
  		size_t n = MIN(rqstd - count, sizeof data);
 
-		n = getrandom(data, n, 0);
+		n = syscall(SYS_getrandom, data, n, 0);
 
 		if (n == -1) {
 			break;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -51,7 +51,7 @@
 #define HAVE_ARC4RANDOM
 #endif
 
-#if defined(__FreeBSD_kernel__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD_kernel__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(BSD)
 #define HAVE_ARC4RANDOM
 #endif
 


### PR DESCRIPTION
Instead of relying on deprecated `sysctl()` use `arc4random()` on *BSDs, `getrandom()` on Linux and just read `/dev/urandom` everywhere else. This should definitely fix https://github.com/wahern/luaossl/issues/54