### PR TITLE
Bindings for X509_VERIFY_PARAM

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -102,6 +102,7 @@ MODS$(1)_$(d) = \
 	$$(DESTDIR)$(3)/openssl/x509/csr.lua \
 	$$(DESTDIR)$(3)/openssl/x509/extension.lua \
 	$$(DESTDIR)$(3)/openssl/x509/store.lua \
+	$$(DESTDIR)$(3)/openssl/x509/verify_param.lua \
 	$$(DESTDIR)$(3)/openssl/pkcs12.lua \
 	$$(DESTDIR)$(3)/openssl/ssl/context.lua \
 	$$(DESTDIR)$(3)/openssl/ssl.lua \

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -286,6 +286,10 @@
 #define HAVE_SSLV2_SERVER_METHOD (!OPENSSL_PREREQ(1,1,0) && !defined OPENSSL_NO_SSL2)
 #endif
 
+#ifndef HAVE_X509_AUTH_LEVEL
+#define HAVE_X509_AUTH_LEVEL OPENSSL_PREREQ(1,1,0)
+#endif
+
 #ifndef HAVE_X509_STORE_REFERENCES
 #define HAVE_X509_STORE_REFERENCES (!OPENSSL_PREREQ(1,1,0))
 #endif
@@ -8340,6 +8344,29 @@ static int xp_getDepth(lua_State *L) {
 } /* xp_getDepth() */
 
 
+#if HAVE_X509_AUTH_LEVEL
+static int xp_setAuthLevel(lua_State *L) {
+	X509_VERIFY_PARAM *xp = checksimple(L, 1, X509_VERIFY_PARAM_CLASS);
+	int auth_level = luaL_checkinteger(L, 2);
+
+	X509_VERIFY_PARAM_set_auth_level(xp, auth_level);
+
+	lua_pushboolean(L, 1);
+	return 1;
+} /* xp_setAuthLevel() */
+
+
+static int xp_getAuthLevel(lua_State *L) {
+	X509_VERIFY_PARAM *xp = checksimple(L, 1, X509_VERIFY_PARAM_CLASS);
+
+	int auth_level = X509_VERIFY_PARAM_get_auth_level(xp);
+
+	lua_pushinteger(L, auth_level);
+	return 1;
+} /* xp_getAuthLevel() */
+#endif
+
+
 static int xp_setHost(lua_State *L) {
 	X509_VERIFY_PARAM *xp = checksimple(L, 1, X509_VERIFY_PARAM_CLASS);
 	size_t len;
@@ -8410,6 +8437,10 @@ static const auxL_Reg xp_methods[] = {
 	{ "setTime", &xp_setTime },
 	{ "setDepth", &xp_setDepth },
 	{ "getDepth", &xp_getDepth },
+#if HAVE_X509_AUTH_LEVEL
+	{ "setAuthLevel", &xp_setAuthLevel },
+	{ "getAuthLevel", &xp_getAuthLevel },
+#endif
 	{ "setHost", &xp_setHost },
 	{ "addHost", &xp_addHost },
 	{ "setEmail", &xp_setEmail },

--- a/src/openssl.x509.verify_param.lua
+++ b/src/openssl.x509.verify_param.lua
@@ -1,0 +1,1 @@
+return require('_openssl.x509.verify_param')


### PR DESCRIPTION
Closes #74 

Still unbound:
  - `X509_VERIFY_PARAM_set_flags`
  - `X509_VERIFY_PARAM_clear_flags`
  - `X509_VERIFY_PARAM_get_flags`
  - `X509_VERIFY_PARAM_set_trust`
  - `X509_VERIFY_PARAM_add0_policy` (policy objects aren't bound yet)
  - `X509_VERIFY_PARAM_set1_policies` (see above)
  - `X509_VERIFY_PARAM_set_hostflags` (should be done eventually, along with `SSL_set_hostflags`)
  - `X509_VERIFY_PARAM_get0_peername` (field only useful in combination with a session, which we don't have due to verify_cb not being bound, see https://github.com/openssl/openssl/issues/1885)
  - `X509_VERIFY_PARAM_set1_ip` (no need, already bound `X509_VERIFY_PARAM_set1_ipasc` which takes a string instead of a binary ip address)
