### PR TITLE
Use X509_get_signature_nid instead of X509_get_signature_type to implement cert:getSignatureName()

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -6017,23 +6017,17 @@ static int xc_getPublicKeyDigest(lua_State *L) {
 } /* xc_getPublicKeyDigest() */
 
 
-#if 0
-/*
- * TODO: X509_get_signature_type always seems to return NID_undef. Are we
- * using it wrong or is it broken?
- */
 static int xc_getSignatureName(lua_State *L) {
 	X509 *crt = checksimple(L, 1, X509_CERT_CLASS);
 	int nid;
 
-	if (NID_undef == (nid = X509_get_signature_type(crt)))
+	if (NID_undef == (nid = X509_get_signature_nid(crt)))
 		return 0;
 
 	auxL_pushnid(L, nid);
 
 	return 1;
 } /* xc_getSignatureName() */
-#endif
 
 
 static int xc_sign(lua_State *L) {
@@ -6180,9 +6174,7 @@ static const auxL_Reg xc_methods[] = {
 	{ "getPublicKey",  &xc_getPublicKey },
 	{ "setPublicKey",  &xc_setPublicKey },
 	{ "getPublicKeyDigest", &xc_getPublicKeyDigest },
-#if 0
 	{ "getSignatureName", &xc_getSignatureName },
-#endif
 	{ "sign",          &xc_sign },
 	{ "text",          &xc_text },
 	{ "tostring",      &xc__tostring },

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -302,6 +302,10 @@
 #define HAVE_SSLV2_SERVER_METHOD (!OPENSSL_PREREQ(1,1,0) && !defined OPENSSL_NO_SSL2)
 #endif
 
+#ifndef HAVE_X509_GET_SIGNATURE_NID
+#define HAVE_X509_GET_SIGNATURE_NID (OPENSSL_PREREQ(1,0,2))
+#endif
+
 #ifndef HAVE_X509_STORE_REFERENCES
 #define HAVE_X509_STORE_REFERENCES (!OPENSSL_PREREQ(1,1,0))
 #endif
@@ -1613,6 +1617,10 @@ static int compat_SSL_CTX_set1_param(SSL_CTX *ctx, X509_VERIFY_PARAM *vpm) {
 
 #if !HAVE_X509_GET0_EXT
 #define X509_get0_ext(crt, i) X509_get_ext((crt), (i))
+#endif
+
+#if !HAVE_X509_GET_SIGNATURE_NID
+#define X509_get_signature_nid(crt) OBJ_obj2nid((crt)->sig_alg->algorithm)
 #endif
 
 #if !HAVE_X509_CRL_GET0_EXT


### PR DESCRIPTION
Related to #79

Tested with e.g.:
```lua
x=require"openssl.x509".new([[
-----BEGIN CERTIFICATE-----
MIIFAjCCA+qgAwIBAgIQC6EoMauKfYZOYVncNOdeDTANBgkqhkiG9w0BAQUFADBI
MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMSIwIAYDVQQDExlE
aWdpQ2VydCBTZWN1cmUgU2VydmVyIENBMB4XDTE1MDYwOTAwMDAwMFoXDTE3MDEw
NTEyMDAwMFowZzELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFTAT
BgNVBAcTDFdhbG51dCBDcmVlazEVMBMGA1UEChMMTHVjYXMgR2Fycm9uMRUwEwYD
VQQDDAwqLmJhZHNzbC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
AQDCBOz4jO4EwrPYUNVwWMyTGOtcqGhJsCK1+ZWesSssdj5swEtgTEzqsrTAD4C2
sPlyyYYC+VxBXRMrf3HES7zplC5QN6ZnHGGM9kFCxUbTFocnn3TrCp0RUiYhc2yE
THlV5NFr6AY9SBVSrbMo26r/bv9glUp3aznxJNExtt1NwMT8U7ltQq21fP6u9RXS
M0jnInHHwhR6bCjqN0rf6my1crR+WqIW3GmxV0TbChKr3sMPR3RcQSLhmvkbk+at
IgYpLrG6SRwMJ56j+4v3QHIArJII2YxXhFOBBcvm/mtUmEAnhccQu3Nw72kYQQdF
VXz5ZD89LMOpfOuTGkyG0cqFAgMBAAGjggHHMIIBwzAfBgNVHSMEGDAWgBSQcds3
63PI79zVHhK2NLorWqCmkjAdBgNVHQ4EFgQUne7Be4ELOkdpcRh9ETeTvKUbP/sw
IwYDVR0RBBwwGoIKYmFkc3NsLmNvbYIMKi5iYWRzc2wuY29tMA4GA1UdDwEB/wQE
AwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwYQYDVR0fBFowWDAq
oCigJoYkaHR0cDovL2NybDMuZGlnaWNlcnQuY29tL3NzY2EtZzcuY3JsMCqgKKAm
hiRodHRwOi8vY3JsNC5kaWdpY2VydC5jb20vc3NjYS1nNy5jcmwwQgYDVR0gBDsw
OTA3BglghkgBhv1sAQEwKjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNl
cnQuY29tL0NQUzB4BggrBgEFBQcBAQRsMGowJAYIKwYBBQUHMAGGGGh0dHA6Ly9v
Y3NwLmRpZ2ljZXJ0LmNvbTBCBggrBgEFBQcwAoY2aHR0cDovL2NhY2VydHMuZGln
aWNlcnQuY29tL0RpZ2lDZXJ0U2VjdXJlU2VydmVyQ0EuY3J0MAwGA1UdEwEB/wQC
MAAwDQYJKoZIhvcNAQEFBQADggEBAGNcYNDbTZP5rkHwTr//KhFqXhVclWGVBGrY
DqGigBJKnhU7gHpPqknLhtrYr/Hihzaj5tvKmN9aPFzflRyn6cuy2fXiIFxN9NNt
zkrp4iAyKQwbYAGb6tuE7xu9p8dLIF/ZnRvb64J5Pt/92s/9jFAb3W9xgpIjA2Tw
AFco+osDP7nMkECTu3DIVlmoTWp3lKoV7l4TEMgHxM3H+iQl+9uKHLIuoVK5KD/Y
UCKyBAy0gYO4w0oM+bKsiVzdBOYm+vUJXjTNTOCrAruYY34HV26qYYpT/D6Vd4SM
TUtfbqM4Bg6CY1ehIoeVEnGhhGG68QsHtAEyaBQpyVg6V+ZcIXg=
-----END CERTIFICATE-----]])
print(x:getSignatureName())
```
(cert is from sha1-2017.badssl.com)

Output:
```
RSA-SHA1
```