### PR TITLE
add support to create subjectKeyIdentifier and authorityKeyIdentifier

### DIFF
--- a/doc/luaossl.tex
+++ b/doc/luaossl.tex
@@ -526,6 +526,10 @@ Returns the basic constraints critical flag as a boolean.
 
 Sets the basic constraints critical flag.
 
+\subsubsection[\fn{x509:setKeyIdentifier}]{\fn{x509:setKeyIdentifier($which$[, $x509$])}}
+
+Sets the key identifier flag. $which$ has to be one of ``subjectKeyIdentifier'' or ``authorityKeyIdentifier''. If $x509$ is specified it will be used to calculate the hash for authorityKeyIdentifier.
+
 \subsubsection[\fn{x509:addExtension}]{\fn{x509:addExtension($ext$)}}
 
 Adds a copy of the \module{x509.extension} object to the certificate. 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5324,7 +5324,7 @@ static int xc_setKeyIdentifier(lua_State *L) {
   }
 
   if (!ex)
-    return luaL_error(L, "x509.cert:setKeyIdentifier: cannot create key identifier %s", nid);
+    return auxL_error(L, auxL_EOPENSSL, "x509.cert:setKeyIdentifier");
 
   X509_add_ext(crt, ex, -1);
   X509_EXTENSION_free(ex);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5305,7 +5305,12 @@ static int xc_setKeyIdentifier(lua_State *L) {
   ASN1_OBJECT_free(obj);
 
   X509V3_set_ctx_nodb(&ctx);
-  X509V3_set_ctx(&ctx, crt, crt, NULL, NULL, 0);
+  if (lua_gettop(L) == 3 && strcmp(nid, "authorityKeyIdentifier") == 0) {
+    X509 *ca = checksimple(L, 3, X509_CERT_CLASS);
+    X509V3_set_ctx(&ctx, ca, crt, NULL, NULL, 0);
+  } else {
+    X509V3_set_ctx(&ctx, crt, crt, NULL, NULL, 0);
+  }
 
   switch (auxL_checkoption(L, 2, 0, (const char *[]){ "subjectKeyIdentifier", "authorityKeyIdentifier", NULL }, 1)) {
     case 0:


### PR DESCRIPTION
as described in https://github.com/wahern/luaossl/issues/87 I wrote a function to add the key identifiers to a x509 object.