### PR TITLE
PF-updates

### DIFF
--- a/doc/luaossl.tex
+++ b/doc/luaossl.tex
@@ -268,9 +268,11 @@ Add or interpose a bignum class method. Returns the previous method, if any.
 
 \module{openssl.pkey} binds OpenSSL's libcrypto public-private key library. The \fn{\_\_tostring} metamethod generates a PEM encoded representation of the public key---excluding the private key.
 
-\subsubsection[\fn{pkey.new}]{\fn{pkey.new($string$[, $format$])}}
+\subsubsection[\fn{pkey.new}]{\fn{pkey.new([$string$[, $format$[, $keytype$[, $passphrase$]]]])}}
 
 Initializes a new pkey object from the PEM- or DER-encoded key in $string$. $format$ defaults to ``*'', which means to automatically test the input encoding. If $format$ is explicitly ``PEM'' or ``DER'', then only that decoding format is used.
+$keytype$ defaults to both private and public key, but can be set explicitly to ``private'' or ``public''.
+$passphrase$ is the decoding passphrase. When absent or nil, while a password is required, the default OpenSSL callback will be used, which will typically prompt for the passphrase on the current terminal with echoing turned off.
 
 On failure throws an error.
 
@@ -280,14 +282,23 @@ Generates a new pkey object according to the specified parameters.
 
 \begin{ctabular}{ c | c | p{5in}}
 field & type:default & description\\\hline
-.type & string:RSA & public key algorithm---``RSA'', ``DSA'', ``EC'', ``DH'', or an internal OpenSSL identifier of a subclass of one of those basic types \\
+.type & string:RSA & public key algorithm---``RSA'', ``DSA'', ``EC'', ``DH'', 
+or an internal OpenSSL identifier of a subclass 
+of one of those basic types \\
 
 .bits & number:1024 & private key size \\
 
 .exp & number:65537 & RSA or Diffie-Hellman exponent \\
 
+.generator & number:2 & DH parameter generator (usually 2 or 5) \\
+
+.dhparam & string & PEM encoded string with precomputed DH parameters \\
+
 .curve & string:prime192v1 & for elliptic curve keys, the OpenSSL string identifier of the curve
 \end{ctabular}
+
+The DH parameters ``dhparam'' will be generated on the fly, ``bits'' wide. This is a slow process, and especially for larger sizes, you would precompute those; for example: ``openssl dhparam -2 -out dh-2048.pem -outform PEM 2048''. Using the field ``dhparam'' overrides the ``bits'' field.
+
 \subsubsection[\fn{pkey.interpose}]{\fn{pkey.interpose($name$, $function$)}}
 
 Add or interpose a pkey class method. Returns the previous method, if any.
@@ -688,6 +699,12 @@ Returns the integer count of the number of extensions.
 
 Signs the instance CRL using the \module{openssl.pkey} $key$.
 
+\subsubsection[\fn{crl:verify}]{\fn{crl:verify($publickey$)}}
+
+Verifies the instance CRL using a public key. The public key $publickey$ of a certificate 
+can be obtained by \module{x509.getPublicKey()}; the one from an \module{openssl.pkey} $key$
+by using \module{tostring($key$)}.
+
 \subsubsection[\fn{crl:text}]{\fn{crl:text()}}
 
 Returns a human-readable textual representation of the instance CRL.
@@ -762,6 +779,10 @@ Add or interpose a store class method. Returns the previous method, if any.
 \subsubsection[\fn{pkcs12:\_\_tostring}]{\fn{pkcs12:\_\_tostring()}}
 
 Returns a PKCS \#12 binary encoded string.
+
+\subsubsection[\fn{pkcs12.parse}]{\fn{pkcs12.parse($bag$[, $passphrase$])}}
+
+Parses a PKCS\#12 bag, presented as a binary string $bag$. The second parameter $passphrase$ is the passphrase required to decrypt the PKCS\#12 bag. The function returns three items; namely the key, certificate and the CA chain, as their respective objects. If an item is absent, it will be substituted by nil. 
 
 \end{Module}
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -6676,7 +6676,7 @@ static int xx_getNextUpdate(lua_State *L) {
 		updateby = timeutc(time);
 
 	if (isfinite(updateby))
-		lua_pushnumber(L, 1);
+		lua_pushnumber(L, updateby);
 	else
 		lua_pushnil(L);
 


### PR DESCRIPTION
# A few additions and bug fixes

1. pkey.new{} accepts 'dhparam' as named parameter, to provide pre-computed DH parameters to speed up the key generation. The use of 'dhparam' overrides the 'bits' parameter.

2. pkey.new{} uses named parameter 'generator' (which defaults to 2) to specify the DH generator, and not the 'exp' parameter, which defaults to 65537. 

3. pkey.new() accepts an optional passphrase as 4th parameter to allow to load password protected keys.

4. pkcs12.parse(string pkcs12bag[, string passphrase]) added to read a standard PKCS12 file provided as a string. The function returns 3 values (pkey, cert, CA) in their respective object representations.

5. crl:getNextUpdate() always returned 1 as unixtime, bug fixed.
