### PR TITLE
Support luajit2.1.0-beta3

### DIFF
--- a/src/compat52.h
+++ b/src/compat52.h
@@ -46,17 +46,18 @@ static int lua_isinteger(lua_State *L, int index) {
 #define LUA_OK 0
 
 
+#if !defined(luaL_newlibtable)
 static void luaL_setmetatable(lua_State *L, const char *tname) {
 	luaL_getmetatable(L, tname);
 	lua_setmetatable(L, -2);
 } /* luaL_setmetatable() */
-
+#endif
 
 static int lua_absindex(lua_State *L, int idx) {
 	return (idx > 0 || idx <= LUA_REGISTRYINDEX)? idx : lua_gettop(L) + idx + 1;
 } /* lua_absindex() */
 
-
+#if !defined(luaL_newlibtable)
 static void *luaL_testudata(lua_State *L, int arg, const char *tname) {
 	void *p = lua_touserdata(L, arg);
 	int eq;
@@ -70,8 +71,9 @@ static void *luaL_testudata(lua_State *L, int arg, const char *tname) {
 
 	return (eq)? p : 0;
 } /* luaL_testudate() */
+#endif
 
-
+#if !defined(luaL_newlibtable)
 static void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
 	int i, t = lua_absindex(L, -1 - nup);
 
@@ -91,6 +93,7 @@ static void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
 
 #define luaL_newlib(L, l) \
 	(luaL_newlibtable((L), (l)), luaL_setfuncs((L), (l), 0))
+#endif
 
 
 static void luaL_requiref(lua_State *L, const char *modname, lua_CFunction openf, int glb) {


### PR DESCRIPTION
This commit fixes the following error with installing by luarocks:

```
  In file included from src/openssl.c:78:
  src/compat52.h:49: error: static declaration of 'luaL_setmetatable' follows non-static declaration
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:92: note: previous declaration of 'luaL_setmetatable' was here
  src/compat52.h:60: error: static declaration of 'luaL_testudata' follows non-static declaration
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:91: note: previous declaration of 'luaL_testudata' was here
  src/compat52.h:75: error: static declaration of 'luaL_setfuncs' follows non-static declaration
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:88: note: previous declaration of 'luaL_setfuncs' was here
  In file included from src/openssl.c:78:
  src/compat52.h:89:1: warning: "luaL_newlibtable" redefined
  In file included from src/openssl.c:76:
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:123:1: warning: this is the location of the previous definition
  In file included from src/openssl.c:78:
  src/compat52.h:92:1: warning: "luaL_newlib" redefined
  In file included from src/openssl.c:76:
  /home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1/lauxlib.h:125:1: warning: this is the location of the previous definition

  Error: Build error: Failed compiling object src/openssl.o
  gcc -O2 -fPIC -I/home/kenhys/.luaenv/versions/luajit-2.1.0-beta3/include/luajit-2.1 -c src/openssl.c -o src/openssl.o -D_REENTRANT -D_THREAD_SAFE -D_GNU_SOURCE -DLUA_COMPAT_APIINTCASTS -I/usr/include -I/usr/include
```