### PR TITLE
Windows Support

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -569,8 +569,9 @@ static void *prepsimple(lua_State *L, const char *tname, int (*gc)(lua_State *))
 	return p;
 } /* prepsimple() */
 
+#define EXPAND( x ) x
 #define prepsimple_(a, b, c, ...) prepsimple((a), (b), (c))
-#define prepsimple(...) prepsimple_(__VA_ARGS__, 0, 0)
+#define prepsimple(...) EXPAND( prepsimple_(__VA_ARGS__, 0, 0) )
 
 
 static void *checksimple(lua_State *L, int index, const char *tname) {
@@ -1061,7 +1062,7 @@ static void auxL_pushunsigned(lua_State *L, auxL_Unsigned i) {
 } /* auxL_pushunsigned() */
 
 #define auxL_checkinteger_(a, b, c, d, ...) auxL_checkinteger((a), (b), (c), (d))
-#define auxL_checkinteger(...) auxL_checkinteger_(__VA_ARGS__, auxL_IntegerMin, auxL_IntegerMax, 0)
+#define auxL_checkinteger(...) EXPAND( auxL_checkinteger_(__VA_ARGS__, auxL_IntegerMin, auxL_IntegerMax, 0) )
 
 static auxL_Integer (auxL_checkinteger)(lua_State *L, int index, auxL_Integer min, auxL_Integer max) {
 	auxL_Integer i;
@@ -1080,14 +1081,14 @@ static auxL_Integer (auxL_checkinteger)(lua_State *L, int index, auxL_Integer mi
 } /* auxL_checkinteger() */
 
 #define auxL_optinteger_(a, b, c, d, e, ...) auxL_optinteger((a), (b), (c), (d), (e))
-#define auxL_optinteger(...) auxL_optinteger_(__VA_ARGS__, auxL_IntegerMin, auxL_IntegerMax, 0)
+#define auxL_optinteger(...) EXPAND( auxL_optinteger_(__VA_ARGS__, auxL_IntegerMin, auxL_IntegerMax, 0))
 
 static auxL_Integer (auxL_optinteger)(lua_State *L, int index, auxL_Integer def, auxL_Integer min, auxL_Integer max) {
 	return (lua_isnoneornil(L, index))? def : auxL_checkinteger(L, index, min, max);
 } /* auxL_optinteger() */
 
 #define auxL_checkunsigned_(a, b, c, d, ...) auxL_checkunsigned((a), (b), (c), (d))
-#define auxL_checkunsigned(...) auxL_checkunsigned_(__VA_ARGS__, auxL_UnsignedMin, auxL_UnsignedMax, 0)
+#define auxL_checkunsigned(...) EXPAND( auxL_checkunsigned_(__VA_ARGS__, auxL_UnsignedMin, auxL_UnsignedMax, 0))
 
 static auxL_Unsigned (auxL_checkunsigned)(lua_State *L, int index, auxL_Unsigned min, auxL_Unsigned max) {
 	auxL_Unsigned i;
@@ -1107,7 +1108,7 @@ static auxL_Unsigned (auxL_checkunsigned)(lua_State *L, int index, auxL_Unsigned
 } /* auxL_checkunsigned() */
 
 #define auxL_optunsigned_(a, b, c, d, e, ...) auxL_optunsigned((a), (b), (c), (d), (e))
-#define auxL_optunsigned(...) auxL_optunsigned_(__VA_ARGS__, auxL_UnsignedMin, auxL_UnsignedMax, 0)
+#define auxL_optunsigned(...) EXPAND( auxL_optunsigned_(__VA_ARGS__, auxL_UnsignedMin, auxL_UnsignedMax, 0) )
 
 static auxL_Unsigned (auxL_optunsigned)(lua_State *L, int index, auxL_Unsigned def, auxL_Unsigned min, auxL_Unsigned max) {
 	return (lua_isnoneornil(L, index))? def : auxL_checkunsigned(L, index, min, max);
@@ -1231,7 +1232,7 @@ static _Bool auxL_newclass(lua_State *L, const char *name, const auxL_Reg *metho
 } /* auxL_newclass() */
 
 #define auxL_addclass(L, ...) \
-	(auxL_newclass((L), __VA_ARGS__), lua_pop((L), 1))
+	EXPAND( (auxL_newclass((L), __VA_ARGS__), lua_pop((L), 1)) )
 
 static int auxL_swaptable(lua_State *L, int index) {
 	index = lua_absindex(L, index);
@@ -1411,7 +1412,7 @@ static struct {
 #endif
 
 #if !HAVE_DH_GET0_KEY
-#define DH_get0_key(...) compat_DH_get0_key(__VA_ARGS__)
+#define DH_get0_key(...) EXPAND( compat_DH_get0_key(__VA_ARGS__) )
 
 static void compat_DH_get0_key(const DH *d, const BIGNUM **pub_key, const BIGNUM **priv_key) {
 	if (pub_key)
@@ -1422,7 +1423,7 @@ static void compat_DH_get0_key(const DH *d, const BIGNUM **pub_key, const BIGNUM
 #endif
 
 #if !HAVE_DH_GET0_PQG
-#define DH_get0_pqg(...) compat_DH_get0_pqg(__VA_ARGS__)
+#define DH_get0_pqg(...) EXPAND( compat_DH_get0_pqg(__VA_ARGS__) )
 
 static void compat_DH_get0_pqg(const DH *d, const BIGNUM **p, const BIGNUM **q, const BIGNUM **g) {
 	if (p)
@@ -1435,7 +1436,7 @@ static void compat_DH_get0_pqg(const DH *d, const BIGNUM **p, const BIGNUM **q, 
 #endif
 
 #if !HAVE_DH_SET0_KEY
-#define DH_set0_key(...) compat_DH_set0_key(__VA_ARGS__)
+#define DH_set0_key(...) EXPAND( compat_DH_set0_key(__VA_ARGS__) )
 
 static void compat_DH_set0_key(DH *d, BIGNUM *pub_key, BIGNUM *priv_key) {
 	if (pub_key)
@@ -1446,7 +1447,7 @@ static void compat_DH_set0_key(DH *d, BIGNUM *pub_key, BIGNUM *priv_key) {
 #endif
 
 #if !HAVE_DH_SET0_PQG
-#define DH_set0_pqg(...) compat_DH_set0_pqg(__VA_ARGS__)
+#define DH_set0_pqg(...) EXPAND( compat_DH_set0_pqg(__VA_ARGS__) )
 
 static void compat_DH_set0_pqg(DH *d, BIGNUM *p, BIGNUM *q, BIGNUM *g) {
 	if (p)
@@ -1459,7 +1460,7 @@ static void compat_DH_set0_pqg(DH *d, BIGNUM *p, BIGNUM *q, BIGNUM *g) {
 #endif
 
 #if !HAVE_DSA_GET0_KEY
-#define DSA_get0_key(...) compat_DSA_get0_key(__VA_ARGS__)
+#define DSA_get0_key(...) EXPAND( compat_DSA_get0_key(__VA_ARGS__) )
 
 static void compat_DSA_get0_key(const DSA *d, const BIGNUM **pub_key, const BIGNUM **priv_key) {
 	if (pub_key)
@@ -1470,7 +1471,7 @@ static void compat_DSA_get0_key(const DSA *d, const BIGNUM **pub_key, const BIGN
 #endif
 
 #if !HAVE_DSA_GET0_PQG
-#define DSA_get0_pqg(...) compat_DSA_get0_pqg(__VA_ARGS__)
+#define DSA_get0_pqg(...) EXPAND( compat_DSA_get0_pqg(__VA_ARGS__) )
 
 static void compat_DSA_get0_pqg(const DSA *d, const BIGNUM **p, const BIGNUM **q, const BIGNUM **g) {
 	if (p)
@@ -1483,7 +1484,7 @@ static void compat_DSA_get0_pqg(const DSA *d, const BIGNUM **p, const BIGNUM **q
 #endif
 
 #if !HAVE_DSA_SET0_KEY
-#define DSA_set0_key(...) compat_DSA_set0_key(__VA_ARGS__)
+#define DSA_set0_key(...) EXPAND( compat_DSA_set0_key(__VA_ARGS__) )
 
 static void compat_DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key) {
 	if (pub_key)
@@ -1494,7 +1495,7 @@ static void compat_DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key) {
 #endif
 
 #if !HAVE_DSA_SET0_PQG
-#define DSA_set0_pqg(...) compat_DSA_set0_pqg(__VA_ARGS__)
+#define DSA_set0_pqg(...) EXPAND( compat_DSA_set0_pqg(__VA_ARGS__) )
 
 static void compat_DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g) {
 	if (p)
@@ -1552,7 +1553,7 @@ static int compat_EVP_PKEY_base_id(EVP_PKEY *key) {
 
 #if !HAVE_EVP_PKEY_GET_DEFAULT_DIGEST_NID
 #define EVP_PKEY_get_default_digest_nid(...) \
-	compat_EVP_PKEY_get_default_digest_nid(__VA_ARGS__)
+	EXPAND( compat_EVP_PKEY_get_default_digest_nid(__VA_ARGS__) )
 
 static int compat_EVP_PKEY_get_default_digest_nid(EVP_PKEY *key, int *nid) {
 	switch (EVP_PKEY_base_id(key)) {
@@ -1633,7 +1634,7 @@ static HMAC_CTX *compat_HMAC_CTX_new(void) {
 #endif
 
 #if !HAVE_RSA_GET0_CRT_PARAMS
-#define RSA_get0_crt_params(...) compat_RSA_get0_crt_params(__VA_ARGS__)
+#define RSA_get0_crt_params(...) EXPAND( compat_RSA_get0_crt_params(__VA_ARGS__) )
 
 static void compat_RSA_get0_crt_params(const RSA *r, const BIGNUM **dmp1, const BIGNUM **dmq1, const BIGNUM **iqmp) {
 	if (dmp1)
@@ -1646,7 +1647,7 @@ static void compat_RSA_get0_crt_params(const RSA *r, const BIGNUM **dmp1, const 
 #endif
 
 #if !HAVE_RSA_GET0_FACTORS
-#define RSA_get0_factors(...) compat_RSA_get0_factors(__VA_ARGS__)
+#define RSA_get0_factors(...) EXPAND( compat_RSA_get0_factors(__VA_ARGS__) )
 
 static void compat_RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q) {
 	if (p)
@@ -1657,7 +1658,7 @@ static void compat_RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM
 #endif
 
 #if !HAVE_RSA_GET0_KEY
-#define RSA_get0_key(...) compat_RSA_get0_key(__VA_ARGS__)
+#define RSA_get0_key(...) EXPAND( compat_RSA_get0_key(__VA_ARGS__) )
 
 static void compat_RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d) {
 	if (n)
@@ -1670,7 +1671,7 @@ static void compat_RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e
 #endif
 
 #if !HAVE_RSA_SET0_CRT_PARAMS
-#define RSA_set0_crt_params(...) compat_RSA_set0_crt_params(__VA_ARGS__)
+#define RSA_set0_crt_params(...) EXPAND( compat_RSA_set0_crt_params(__VA_ARGS__) )
 
 static void compat_RSA_set0_crt_params(RSA *r, BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqmp) {
 	if (dmp1)
@@ -1683,7 +1684,7 @@ static void compat_RSA_set0_crt_params(RSA *r, BIGNUM *dmp1, BIGNUM *dmq1, BIGNU
 #endif
 
 #if !HAVE_RSA_SET0_FACTORS
-#define RSA_set0_factors(...) compat_RSA_set0_factors(__VA_ARGS__)
+#define RSA_set0_factors(...) EXPAND( compat_RSA_set0_factors(__VA_ARGS__) )
 
 static void compat_RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q) {
 	if (p)
@@ -1694,7 +1695,7 @@ static void compat_RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q) {
 #endif
 
 #if !HAVE_RSA_SET0_KEY
-#define RSA_set0_key(...) compat_RSA_set0_key(__VA_ARGS__)
+#define RSA_set0_key(...) EXPAND( compat_RSA_set0_key(__VA_ARGS__) )
 
 static void compat_RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
 	if (n)
@@ -1707,7 +1708,7 @@ static void compat_RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
 #endif
 
 #if !HAVE_SSL_GET_CLIENT_RANDOM
-#define SSL_get_client_random(...) compat_SSL_get_client_random(__VA_ARGS__)
+#define SSL_get_client_random(...) EXPAND( compat_SSL_get_client_random(__VA_ARGS__) )
 static size_t compat_SSL_get_client_random(const SSL *ssl, unsigned char *out, size_t outlen) {
     if (outlen == 0)
         return sizeof(ssl->s3->client_random);
@@ -1719,7 +1720,7 @@ static size_t compat_SSL_get_client_random(const SSL *ssl, unsigned char *out, s
 #endif
 
 #if !HAVE_SSL_CLIENT_VERSION
-#define SSL_client_version(...) compat_SSL_client_version(__VA_ARGS__)
+#define SSL_client_version(...) EXPAND( compat_SSL_client_version(__VA_ARGS__) )
 
 static int compat_SSL_client_version(const SSL *ssl) {
 	return ssl->client_version;
@@ -1743,7 +1744,7 @@ static int compat_SSL_set1_param(SSL *ssl, X509_VERIFY_PARAM *vpm) {
 #endif
 
 #if !HAVE_SSL_UP_REF
-#define SSL_up_ref(...) compat_SSL_up_ref(__VA_ARGS__)
+#define SSL_up_ref(...) EXPAND( compat_SSL_up_ref(__VA_ARGS__) )
 
 static int compat_SSL_up_ref(SSL *ssl) {
 	/* our caller should already have had a proper reference */
@@ -1909,7 +1910,7 @@ static void compat_init_X509_STORE_onfree(void *store, void *data NOTUSED, CRYPT
 } /* compat_init_X509_STORE_onfree() */
 
 #if !HAVE_X509_STORE_UP_REF
-#define X509_STORE_up_ref(...) compat_X509_STORE_up_ref(__VA_ARGS__)
+#define X509_STORE_up_ref(...) EXPAND( compat_X509_STORE_up_ref(__VA_ARGS__) )
 
 static int compat_X509_STORE_up_ref(X509_STORE *crt) {
 	/* our caller should already have had a proper reference */
@@ -1921,7 +1922,7 @@ static int compat_X509_STORE_up_ref(X509_STORE *crt) {
 #endif
 
 #if !HAVE_X509_UP_REF
-#define X509_up_ref(...) compat_X509_up_ref(__VA_ARGS__)
+#define X509_up_ref(...) EXPAND( compat_X509_up_ref(__VA_ARGS__) )
 
 static int compat_X509_up_ref(X509 *crt) {
 	/* our caller should already have had a proper reference */
@@ -2587,7 +2588,7 @@ static BIGNUM *bn_dup_nil(lua_State *L, const BIGNUM *src) {
 
 
 #define checkbig_(a, b, c, ...) checkbig((a), (b), (c))
-#define checkbig(...) checkbig_(__VA_ARGS__, &(_Bool){ 0 }, 0)
+#define checkbig(...) EXPAND( checkbig_(__VA_ARGS__, &(_Bool){ 0 }, 0) )
 
 static BIGNUM *(checkbig)(lua_State *, int, _Bool *);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -38,8 +38,8 @@
 
 #include <sys/stat.h>     /* struct stat stat(2) */
 #ifdef _WIN32
-#include <inaddr.h>       /* struct in_addr, struct in6_addr */
 #include <winsock2.h>     /* AF_INET, AF_INET6 */
+#include <inaddr.h>       /* struct in_addr, struct in6_addr */
 #include <ws2tcpip.h>     /* inet_pton */
 #pragma comment(lib, "ws2_32.lib")
 #include <wincrypt.h>     /* CryptAcquireContext(), CryptGenRandom(), CryptReleaseContext() */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -493,6 +493,10 @@
 #define MIN(a, b) (((a) < (b))? (a) : (b))
 
 #ifdef _WIN32
+#if !defined(S_ISDIR) && defined(_S_IFDIR) && defined(_S_IFDIR)
+#define S_ISDIR(m) (((m) & _S_IFDIR) == _S_IFDIR)
+#endif
+
 #define stricmp(a, b) _stricmp((a), (b))
 #else
 #include <strings.h>      /* strcasecmp(3) */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -41,11 +41,8 @@
 #include <winsock2.h>     /* AF_INET, AF_INET6 */
 #include <inaddr.h>       /* struct in_addr, struct in6_addr */
 #include <ws2tcpip.h>     /* inet_pton */
-#pragma comment(lib, "ws2_32.lib")
 #include <wincrypt.h>     /* CryptAcquireContext(), CryptGenRandom(), CryptReleaseContext() */
-#pragma comment(lib, "advapi32.lib")
 #include <windows.h>      /* CreateMutex(), GetLastError(), GetModuleHandleEx(), GetProcessTimes(), InterlockedCompareExchangePointer() */
-#pragma comment(lib, "kernel32.lib")
 #define EXPORT  __declspec (dllexport)
 #else
 #include <arpa/inet.h>    /* inet_pton(3) */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1342,7 +1342,15 @@ static const EVP_MD *auxL_optdigest(lua_State *L, int index, EVP_PKEY *key, cons
  */
 /* dl_anchor must not be called from multiple threads at once */
 static int dl_anchor(void) {
-#if HAVE_DLADDR
+#if _WIN32
+	EXPORT extern int luaopen__openssl(lua_State *);
+
+	HMODULE dummy;
+	if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_PIN|GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (void *)&luaopen__openssl, &dummy))
+		return GetLastError();
+
+	return 0;
+#elif HAVE_DLADDR
 	extern int luaopen__openssl(lua_State *);
 	static void *anchor;
 	Dl_info info;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -811,11 +811,10 @@ static const char *aux_strerror_r(int error, char *dst, size_t lim) {
 	size_t n;
 
 #if _WIN32
-	char *rv = strerror(error);
-	n = MIN(strlen(rv) - 1, lim);
-	memcpy(dst, rv, n);
-	return dst;
+	errno_t rv = strerror_s(dst, lim, error);
 
+	if (rv)
+		return dst;
 #elif STRERROR_R_CHAR_P
 	char *rv = strerror_r(error, dst, lim);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -30,7 +30,6 @@
 #include <limits.h>       /* INT_MAX INT_MIN LLONG_MAX LLONG_MIN UCHAR_MAX ULLONG_MAX */
 #include <stdint.h>       /* uintptr_t */
 #include <string.h>       /* memset(3) strerror_r(3) */
-#include <strings.h>      /* strcasecmp(3) */
 #include <math.h>         /* INFINITY fabs(3) floor(3) frexp(3) fmod(3) round(3) isfinite(3) */
 #include <time.h>         /* struct tm time_t strptime(3) time(2) */
 #include <ctype.h>        /* isdigit(3), isxdigit(3), tolower(3) */
@@ -493,7 +492,12 @@
 #undef MIN
 #define MIN(a, b) (((a) < (b))? (a) : (b))
 
+#ifdef _WIN32
+#define stricmp(a, b) _stricmp((a), (b))
+#else
+#include <strings.h>      /* strcasecmp(3) */
 #define stricmp(a, b) strcasecmp((a), (b))
+#endif
 #define strieq(a, b) (!stricmp((a), (b)))
 
 #define xtolower(c) tolower((unsigned char)(c))
@@ -988,7 +992,13 @@ NOTUSED static auxtype_t auxL_getref(lua_State *L, auxref_t ref) {
 
 static int auxL_testoption(lua_State *L, int index, const char *def, const char *const *optlist, _Bool nocase) {
 	const char *optname = (def)? luaL_optstring(L, index, def) : luaL_checkstring(L, index);
-	int (*optcmp)() = (nocase)? &strcasecmp : &strcmp;
+	int (*optcmp)() = (nocase)?
+#ifdef _WIN32
+		&_stricmp
+#else
+		&strcasecmp
+#endif
+		: &strcmp;
 	int i;
 
 	for (i = 0; optlist[i]; i++) {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -52,10 +52,10 @@
 #endif
 #include <fcntl.h>        /* O_RDONLY O_CLOEXEC open(2) */
 #include <unistd.h>       /* close(2) getpid(2) */
-#include <pthread.h>      /* pthread_mutex_init(3) pthread_mutex_lock(3) pthread_mutex_unlock(3) */
 #ifdef __WIN32
 #define EXPORT  __declspec (dllexport)
 #else
+#include <pthread.h>      /* pthread_mutex_init(3) pthread_mutex_lock(3) pthread_mutex_unlock(3) */
 #include <sys/resource.h> /* RUSAGE_SELF struct rusage getrusage(2) */
 #include <sys/utsname.h>  /* struct utsname uname(3) */
 #include <dlfcn.h>        /* dladdr(3) dlopen(3) */
@@ -10414,15 +10414,27 @@ EXPORT int luaopen__openssl_des(lua_State *L) {
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 static struct {
+#if _WIN32
+	HANDLE *lock;
+#else
 	pthread_mutex_t *lock;
+#endif
 	int nlock;
 } mt_state;
 
 static void mt_lock(int mode, int type, const char *file NOTUSED, int line NOTUSED) {
 	if (mode & CRYPTO_LOCK)
+#if _WIN32
+		WaitForSingleObject(mt_state.lock[type], INFINITE);
+#else
 		pthread_mutex_lock(&mt_state.lock[type]);
+#endif
 	else
+#if _WIN32
+		ReleaseMutex(mt_state.lock[type]);
+#else
 		pthread_mutex_unlock(&mt_state.lock[type]);
+#endif
 } /* mt_lock() */
 
 /*
@@ -10448,6 +10460,8 @@ static unsigned long mt_gettid(void) {
 	return id;
 #elif __NetBSD__
 	return _lwp_self();
+#elif _WIN32
+	return GetCurrentThreadId();
 #else
 	/*
 	 * pthread_t is an integer on Solaris and Linux, an unsigned integer
@@ -10477,9 +10491,18 @@ static int mt_init(void) {
 			}
 
 			for (i = 0; i < mt_state.nlock; i++) {
+#if _WIN32
+				if (!(mt_state.lock[i] = CreateMutex(NULL, FALSE, NULL))) {
+					error = GetLastError();
+#else
 				if ((error = pthread_mutex_init(&mt_state.lock[i], NULL))) {
+#endif
 					while (i > 0) {
+#if _WIN32
+						CloseHandle(mt_state.lock[--i]);
+#else
 						pthread_mutex_destroy(&mt_state.lock[--i]);
+#endif
 					}
 
 					free(mt_state.lock);
@@ -10511,11 +10534,24 @@ epilog:
 
 
 static void initall(lua_State *L) {
-	static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 	static int initssl;
 	int error = 0;
 
+#if _WIN32
+	static volatile HANDLE mutex = NULL;
+	if (mutex == NULL) {
+		HANDLE p;
+		if (!(p = CreateMutex(NULL, FALSE, NULL)))
+			auxL_error(L, GetLastError(), "openssl.init");
+		if (InterlockedCompareExchangePointer((PVOID*)&mutex, (PVOID)p, NULL) != NULL)
+			CloseHandle(p);
+	}
+	if (WaitForSingleObject(mutex, INFINITE) == WAIT_FAILED)
+		auxL_error(L, GetLastError(), "openssl.init");
+#else
+	static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 	pthread_mutex_lock(&mutex);
+#endif
 
 #if !OPENSSL_PREREQ(1,1,0)
 	if (!error)
@@ -10542,7 +10578,11 @@ static void initall(lua_State *L) {
 	if (!error)
 		error = ex_init();
 
+#if _WIN32
+	ReleaseMutex(mutex);
+#else
 	pthread_mutex_unlock(&mutex);
+#endif
 
 	if (error)
 		auxL_error(L, error, "openssl.init");


### PR DESCRIPTION
Currently missing build system modifications. GNUmake is not well supported on windows.

Tested with MSVC 2015 and mingw-w64. https://ci.appveyor.com/project/daurnimator/luaossl/build/1.0.71

## Mingw-w64

```
copy config.h.guess src\config.h
gcc -O2 -c -o src/openssl.o -IC:/projects/luaossl/env/include src/openssl.c -D_REENTRANT -D_THREAD_SAFE -DCOMPAT_PREFIX=luaossl -DHAVE_SYS_PARAM_H=0 -DHAVE_DLFCN_H=0 -D_WIN32_WINNT=0x0600 -IC:\OpenSSL-Win64/include -IC:\OpenSSL-Win64/include
gcc -O2 -c -o vendor/compat53/c-api/compat-5.3.o -IC:/projects/luaossl/env/include vendor/compat53/c-api/compat-5.3.c -D_REENTRANT -D_THREAD_SAFE -DCOMPAT_PREFIX=luaossl -DHAVE_SYS_PARAM_H=0 -DHAVE_DLFCN_H=0 -D_WIN32_WINNT=0x0600 -IC:\OpenSSL-Win64/include -IC:\OpenSSL-Win64/include
gcc -shared -o _openssl.dll src/openssl.o vendor/compat53/c-api/compat-5.3.o -LC:\OpenSSL-Win64/lib -LC:\OpenSSL-Win64/lib -llibeay32 -lssleay32 -lws2_32 -ladvapi32 -lkernel32 C:/projects/luaossl/env/bin/lua53.dll -lm
```

## MSVC

```
copy config.h.guess src\config.h
cl /nologo /MD /O2 -c -Fosrc/openssl.obj -IC:/projects/luaossl/env/include src/openssl.c -D_REENTRANT -D_THREAD_SAFE -DCOMPAT_PREFIX=luaossl -DHAVE_SYS_PARAM_H=0 -DHAVE_DLFCN_H=0 -D_WIN32_WINNT=0x0600 -IC:\OpenSSL-Win64/include -IC:\OpenSSL-Win64/include
cl /nologo /MD /O2 -c -Fovendor/compat53/c-api/compat-5.3.obj -IC:/projects/luaossl/env/include vendor/compat53/c-api/compat-5.3.c -D_REENTRANT -D_THREAD_SAFE -DCOMPAT_PREFIX=luaossl -DHAVE_SYS_PARAM_H=0 -DHAVE_DLFCN_H=0 -D_WIN32_WINNT=0x0600 -IC:\OpenSSL-Win64/include -IC:\OpenSSL-Win64/include
link -dll -def:_openssl.def -out:_openssl.dll C:/projects/luaossl/env/lib/lua52.lib src/openssl.obj vendor/compat53/c-api/compat-5.3.obj -libpath:C:\OpenSSL-Win64/lib -libpath:C:\OpenSSL-Win64/lib libeay32.lib ssleay32.lib ws2_32.lib advapi32.lib kernel32.lib
```

--------------

Closes #77