### PR TITLE
pkey.new() segfaults

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3338,7 +3338,7 @@ static int pk_new(lua_State *L) {
 		if (!(*ud = EVP_PKEY_new()))
 			return auxL_error(L, auxL_EOPENSSL, "pkey.new");
 
-		switch (EVP_PKEY_type(type)) {
+		switch (type) {
 		case EVP_PKEY_RSA: {
 			RSA *rsa;
 


### PR DESCRIPTION
Fix bug where a NULL exp would be in `pkey.new()`

Approach taken was to move the `nil` goto, as otherwise would require moving allocations around.