### PR TITLE
ssl:getcertificate()

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -9186,6 +9186,19 @@ static int ssl_setPrivateKey(lua_State *L) {
 } /* ssl_setPrivateKey() */
 
 
+static int ssl_getCertificate(lua_State *L) {
+	SSL *ssl = checksimple(L, 1, SSL_CLASS);
+	X509 *x509;
+
+	if (!(x509 = SSL_get_certificate(ssl)))
+		return 0;
+
+	xc_dup(L, x509);
+
+	return 1;
+} /* ssl_getCertificate() */
+
+
 static int ssl_getPeerCertificate(lua_State *L) {
 	SSL *ssl = checksimple(L, 1, SSL_CLASS);
 	X509 **x509 = prepsimple(L, X509_CERT_CLASS);
@@ -9520,6 +9533,7 @@ static const auxL_Reg ssl_methods[] = {
 	{ "getVerifyResult",  &ssl_getVerifyResult },
 	{ "setCertificate",   &ssl_setCertificate },
 	{ "setPrivateKey",    &ssl_setPrivateKey },
+	{ "getCertificate",   &ssl_getCertificate },
 	{ "getPeerCertificate", &ssl_getPeerCertificate },
 	{ "getPeerChain",     &ssl_getPeerChain },
 	{ "getCipherInfo",    &ssl_getCipherInfo },

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5648,6 +5648,18 @@ EXPORT int luaopen__openssl_x509_extension(lua_State *L) {
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+static void xc_dup(lua_State *L, X509 *x509) {
+	X509 **ud = prepsimple(L, X509_CERT_CLASS);
+
+	if (!(*ud = X509_dup(x509)))
+		goto error;
+
+	return;
+error:
+	auxL_error(L, auxL_EOPENSSL, "X509_dup");
+} /* xc_dup() */
+
+
 static int xc_new(lua_State *L) {
 	const char *data;
 	size_t len;
@@ -7713,10 +7725,7 @@ static int xl__next(lua_State *L) {
 
 		lua_pushinteger(L, i);
 
-		ret = prepsimple(L, X509_CERT_CLASS);
-
-		if (!(*ret = X509_dup(crt)))
-			return auxL_error(L, auxL_EOPENSSL, "x509.chain:__next");
+		xc_dup(L, crt);
 
 		break;
 	}


### PR DESCRIPTION
Add ssl:getCertificate()

It uses X509_dup to match :setCertificate().
Note that this differs from ssl:getPeerCertificate() which does *not* dup().

Closes #120