### PR TITLE
Use DER true value of 0xFF

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -6353,7 +6353,7 @@ static int xc_setBasicConstraint(lua_State *L) {
 	}
 
 	if (CA != -1)
-		bs->ca = CA;
+		bs->ca = CA ? 0xFF : 0; /* use DER value */
 
 	if (pathLen >= 0) {
 		ASN1_INTEGER_free(bs->pathlen);


### PR DESCRIPTION
The basic contraints field of `ca` is used directly in the output DER/PEM.
To get the correct serialisation, we need to use the DER truth encoding of 0xFF.

Some TLS stacks are fussy about this (e.g. go-lang's)
Many thanks to this comment https://github.com/zmap/zgrab/issues/180#issuecomment-245132628