### PR TITLE
src/openssl.c: add pushlightuserdata functions

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -9138,6 +9138,19 @@ static void sx_push(lua_State *L, SSL_CTX *ctx) {
 } /* sx_push() */
 
 
+static int sx_pushlightuserdata(lua_State *L) {
+	SSL_CTX *ptr;
+
+	luaL_checktype(L, 1, LUA_TLIGHTUSERDATA);
+	ptr = lua_touserdata(L, 1);
+	luaL_argcheck(L, ptr, 1, "SSL_CTX* pointer must be non-null");
+
+	sx_push(L, ptr);
+
+	return 1;
+} /* sx_pushlightuserdata() */
+
+
 static int sx_pushffi(lua_State *L) {
 	SSL_CTX *ptr;
 
@@ -9152,7 +9165,7 @@ static int sx_pushffi(lua_State *L) {
 	sx_push(L, ptr);
 
 	return 1;
-} /* ssl_pushffi() */
+} /* sx_pushffi() */
 
 
 static int sx_new(lua_State *L) {
@@ -10340,10 +10353,11 @@ static const auxL_Reg sx_metatable[] = {
 };
 
 static const auxL_Reg sx_globals[] = {
-	{ "new",       &sx_new },
-	{ "pushffi",   &sx_pushffi, 1 },
-	{ "interpose", &sx_interpose },
-	{ NULL,        NULL },
+	{ "new",                 &sx_new },
+	{ "pushlightuserdata",   &sx_pushlightuserdata },
+	{ "pushffi",             &sx_pushffi, 1 },
+	{ "interpose",           &sx_interpose },
+	{ NULL,                  NULL },
 };
 
 static const auxL_IntegerReg sx_verify[] = {
@@ -10543,6 +10557,19 @@ static void ssl_push(lua_State *L, SSL *ssl) {
 	}
 	lua_remove(L, -2);
 } /* ssl_push() */
+
+
+static int ssl_pushlightuserdata(lua_State *L) {
+	SSL *ptr;
+
+	luaL_checktype(L, 1, LUA_TLIGHTUSERDATA);
+	ptr = lua_touserdata(L, 1);
+	luaL_argcheck(L, ptr, 1, "SSL* pointer must be non-null");
+
+	ssl_push(L, ptr);
+
+	return 1;
+} /* ssl_pushlightuserdata() */
 
 
 static int ssl_pushffi(lua_State *L) {
@@ -11262,10 +11289,11 @@ static const auxL_Reg ssl_metatable[] = {
 };
 
 static const auxL_Reg ssl_globals[] = {
-	{ "new",       &ssl_new },
-	{ "pushffi",   &ssl_pushffi, 1 },
-	{ "interpose", &ssl_interpose },
-	{ NULL,        NULL },
+	{ "new",               &ssl_new },
+	{ "pushlightuserdata", &ssl_pushlightuserdata },
+	{ "pushffi",           &ssl_pushffi, 1 },
+	{ "interpose",         &ssl_interpose },
+	{ NULL,                NULL },
 };
 
 static const auxL_IntegerReg ssl_version[] = {


### PR DESCRIPTION
This allows external modules to use the object cache.

Note that LuaJIT users will probably need to use pushffi
instead to avoid the 47bit userdata issue

TODO: try and hook this up to cqueues' `checktls` function before merging.