### PR TITLE
src/openssl.c: fix GNU version of strerror_r

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -998,7 +998,7 @@ static const char *aux_strerror_r(int error, char *dst, size_t lim) {
 	char *rv = strerror_r(error, dst, lim);
 
 	if (rv != NULL)
-		return dst;
+		return rv;
 #else
 	int rv = strerror_r(error, dst, lim);
 


### PR DESCRIPTION
GNU version of strerror_r may return pointer to different place than dst
variable, and former version of code was throwing away these results and
returned an empty string from dst.