### PR TITLE
src/openssl.c: Fix reading ASN1_TIME timestamps from before 2000

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -6634,7 +6634,7 @@ static double timeutc(const ASN1_TIME *time) {
 	} else {
 		if (!scan(&year, &cp, 2, 0))
 			goto badfmt;
-		year += (year < 50)? 2000 : 1999;
+		year += (year < 50)? 2000 : 1900;
 	}
 
 	tm.tm_year = year - 1900;


### PR DESCRIPTION
Fixes https://github.com/wahern/luaossl/issues/178

I'm wondering why `xc_setLifetime` uses `ASN1_TIME_set` rather than the `ASN1_GENERALIZEDTIME` apis, as the latter doesn't suffer from Y2K-like problems.