### PR TITLE
support for Lua 5.4

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,7 +12,7 @@ all: # default target
 #
 # G N U  M A K E  F U N C T I O N S
 #
-KNOWN_APIS = 5.1 5.2 5.3
+KNOWN_APIS = 5.1 5.2 5.3 5.4
 
 # template for invoking luapath script
 LUAPATH := $(d)/mk/luapath
@@ -40,6 +40,9 @@ lua52cpath ?= $(libdir)/lua/5.2
 lua52path ?= $(datadir)/lua/5.2
 lua53cpath ?= $(libdir)/lua/5.3
 lua53path ?= $(datadir)/lua/5.3
+lua54cpath ?= $(libdir)/lua/5.4
+lua54path ?= $(datadir)/lua/5.4
+
 
 AR ?= ar
 RANLIB ?= ranlib
@@ -64,7 +67,7 @@ PRINT_$(d) = printf "%s = %s\n" '$(1)' '$(subst ',\\',$(2))' | $(TEE_A) '$(3)'
 
 LAZY_$(d) = \
 	prefix includedir libdir datadir bindir \
-	lua51cpath lua51path lua52cpath lua52path lua53cpath lua53path \
+	lua51cpath lua51path lua52cpath lua52path lua53cpath lua53path lua54cpath lua54path \
 	CC ALL_CPPFLAGS CPPFLAGS ALL_CFLAGS CFLAGS ALL_LDFLAGS LDFLAGS \
 	ALL_SOFLAGS SOFLAGS ALL_LIB LIBS \
 	$(foreach API,$(KNOWN_APIS),ALL_LUA$(subst .,,$(API))_CPPFLAGS) \
@@ -96,7 +99,7 @@ endif
 
 # set LUA_APIS if empty or "?"
 ifeq ($(or $(strip $(LUA_APIS)),?),?)
-override LUA_APIS := $(call HAVE_API_FN,5.1) $(call HAVE_API_FN,5.2) $(call HAVE_API_FN,5.3)
+override LUA_APIS := $(call HAVE_API_FN,5.1) $(call HAVE_API_FN,5.2) $(call HAVE_API_FN,5.3) $(call HAVE_API_FN,5.4)
 endif
 
 define LUAXY_template
@@ -131,6 +134,7 @@ endef # LUAXY_template
 $(eval $(call LUAXY_template,5.1))
 $(eval $(call LUAXY_template,5.2))
 $(eval $(call LUAXY_template,5.3))
+$(eval $(call LUAXY_template,5.4))
 
 #
 # A U T O D E T E C T  C O M P I L A T I O N  F L A G S

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -40,6 +40,7 @@ $$(d)/$(1)/%.o: $$(d)/%.c $$(d)/config.h
 	$$(CC) $$(CFLAGS_$$(<D)) $$(ALL_LUA$(subst .,,$(1))_CPPFLAGS) $$(CPPFLAGS_$$(<D)) -c -o $$@ $$<
 
 ifneq ($(1), 5.3)
+ifneq ($(1), 5.4)
 $$(d)/$(1)/compat53.o: $$(d)/../vendor/compat53/c-api/compat-5.3.c $$(d)/../vendor/compat53/c-api/compat-5.3.h $$(d)/config.h
 	$$(MKDIR) -p $$(@D)
 	$$(CC) $$(CFLAGS_$(d)) $$(ALL_LUA$(subst .,,$(1))_CPPFLAGS) $$(CPPFLAGS_$(d)) -c -o $$@ $$<
@@ -47,6 +48,7 @@ $$(d)/$(1)/compat53.o: $$(d)/../vendor/compat53/c-api/compat-5.3.c $$(d)/../vend
 $$(d)/$(1)/%.o: $$(d)/../vendor/compat53/c-api/compat-5.3.h
 
 $$(d)/$(1)/openssl.so: $$(d)/$(1)/compat53.o
+endif
 endif
 
 .SECONDARY: liblua$(1)-openssl openssl$(1) openssl
@@ -58,13 +60,15 @@ endef # BUILD_$(d)
 $(eval $(call BUILD_$(d),5.1))
 $(eval $(call BUILD_$(d),5.2))
 $(eval $(call BUILD_$(d),5.3))
+$(eval $(call BUILD_$(d),5.4))
 
 ifneq "$(filter $(abspath $(d)/..)/%, $(abspath $(firstword $(MAKEFILE_LIST))))" ""
-.SECONDARY: all all5.1 all5.2 all5.3
+.SECONDARY: all all5.1 all5.2 all5.3 all5.4
 
 all5.1: liblua5.1-openssl
 all5.2: liblua5.2-openssl
 all5.3: liblua5.3-openssl
+all5.4: liblua5.4-openssl
 all: $(foreach API,$(strip $(LUA_APIS)),all$(API))
 
 endif
@@ -152,21 +156,24 @@ endef # INSTALL_$(d)
 $(eval $(call INSTALL_$(d),5.1,$$(lua51cpath),$$(lua51path)))
 $(eval $(call INSTALL_$(d),5.2,$$(lua52cpath),$$(lua52path)))
 $(eval $(call INSTALL_$(d),5.3,$$(lua53cpath),$$(lua53path)))
+$(eval $(call INSTALL_$(d),5.4,$$(lua54cpath),$$(lua54path)))
 
 ifneq "$(filter $(abspath $(d)/..)/%, $(abspath $(firstword $(MAKEFILE_LIST))))" ""
 
-.SECONDARY: install5.1 install5.2 install5.3 install
+.SECONDARY: install5.1 install5.2 install5.3 install5.4 install
 
 install5.1: liblua5.1-openssl-install
 install5.2: liblua5.2-openssl-install
 install5.3: liblua5.3-openssl-install
+install5.4: liblua5.4-openssl-install
 install: $(foreach API,$(strip $(LUA_APIS)),install$(API))
 
-.PHONY: uninstall5.1 uninstall5.2 uninstall5.3 uninstall
+.PHONY: uninstall5.1 uninstall5.2 uninstall5.3 uninstall5.4 uninstall
 
 uninstall5.1: liblua5.1-openssl-uninstall
 uninstall5.2: liblua5.2-openssl-uninstall
 uninstall5.3: liblua5.3-openssl-uninstall
+uninstall5.4: liblua5.4-openssl-uninstall
 uninstall: $(foreach API,$(strip $(LUA_APIS)),uninstall$(API))
 
 endif
@@ -201,14 +208,17 @@ $(d)/help:
 	@echo "      all5.1 - build 5.1/openssl.so"
 	@echo "      all5.2 - build 5.2/openssl.so"
 	@echo "      all5.3 - build 5.3/openssl.so"
+	@echo "      all5.4 - build 5.4/openssl.so"
 	@echo "     install - install all API targets"
 	@echo "  install5.1 - install openssl Lua 5.1 modules"
 	@echo "  install5.2 - install openssl Lua 5.2 modules"
 	@echo "  install5.3 - install openssl Lua 5.3 modules"
+	@echo "  install5.4 - install openssl Lua 5.4 modules"
 	@echo "   uninstall - uninstall all API targets"
 	@echo "uninstall5.1 - uninstall openssl Lua 5.1 modules"
 	@echo "uninstall5.2 - uninstall openssl Lua 5.2 modules"
 	@echo "uninstall5.3 - uninstall openssl Lua 5.3 modules"
+	@echo "uninstall5.4 - uninstall openssl Lua 5.4 modules"
 	@echo "       clean - rm binary targets, object files, debugging symbols, etc"
 	@echo "      clean~ - clean + rm *~"
 	@echo "        help - echo this help message"
@@ -223,10 +233,13 @@ $(d)/help:
 	@echo 'lua52cpath - install path for Lua 5.2 C modules ($(value lua52cpath))'
 	@echo ' lua53path - install path for Lua 5.3 modules ($(value lua53path))'
 	@echo 'lua53cpath - install path for Lua 5.3 C modules ($(value lua53cpath))'
+	@echo ' lua54path - install path for Lua 5.4 modules ($(value lua54path))'
+	@echo 'lua54cpath - install path for Lua 5.4 C modules ($(value lua54cpath))'
 	@echo ""
 	@echo 'LUA51_CPPFLAGS - cpp flags for Lua 5.1 headers ($(LUA51_CPPFLAGS))'
 	@echo 'LUA52_CPPFLAGS - cpp flags for Lua 5.2 headers ($(LUA52_CPPFLAGS))'
 	@echo 'LUA53_CPPFLAGS - cpp flags for Lua 5.3 headers ($(LUA53_CPPFLAGS))'
+	@echo 'LUA54_CPPFLAGS - cpp flags for Lua 5.4 headers ($(LUA54_CPPFLAGS))'
 	@echo ""
 	@echo "(NOTE: all the common GNU-style paths are supported, including"
 	@echo "prefix, bindir, libdir, datadir, includedir, and DESTDIR.)"

--- a/vendor/compat53/c-api/compat-5.3.h
+++ b/vendor/compat53/c-api/compat-5.3.h
@@ -397,11 +397,11 @@ COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
 
 
 /* other Lua versions */
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 503
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 504
 
-#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, or 5.3)"
+#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
 
-#endif /* other Lua versions except 5.1, 5.2, and 5.3 */
+#endif /* other Lua versions except 5.1, 5.2, 5.3, and 5.4 */
 
 
 


### PR DESCRIPTION
cherry-picked from:
https://src.fedoraproject.org/rpms/lua-luaossl/blob/2f38bb943874955fed1ab860467ed822996808da/f/luaossl-rel-20190731-lua-5.4.patch

Closes #182 