### PR TITLE
OpenSSL 3.0.0

### DIFF
--- a/regress/regress.lua
+++ b/regress/regress.lua
@@ -126,7 +126,7 @@ function regress.genkey(type, ca_key, ca_crt)
 	if type == "EC" then
 		key = regress.check(pkey.new{ type = "EC",  curve = "prime192v1" })
 	else
-		key = regress.check(pkey.new{ type = type, bits = 1024 })
+		key = regress.check(pkey.new{ type = type, bits = 2048 })
 	end
 
 	local dn = name.new()

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3920,8 +3920,12 @@ static int bn_generatePrime(lua_State *L) {
 
 static int bn_isPrime(lua_State *L) {
 	BIGNUM *bn = checksimple(L, 1, BIGNUM_CLASS);
+#if OPENSSL_PREREQ(3,0,0)
+	int res = BN_check_prime(bn, getctx(L), NULL);
+#else
 	int nchecks = luaL_optinteger(L, 2, BN_prime_checks);
 	int res = BN_is_prime_ex(bn, nchecks, getctx(L), NULL);
+#endif
 
 	if (res == -1)
 		return auxL_error(L, auxL_EOPENSSL, "bignum:isPrime");

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2267,10 +2267,6 @@ STACK_OF(X509) *compat_X509_chain_up_ref(STACK_OF(X509) *chain) {
 #endif
 
 typedef struct {
-    int nid;
-} EVP_KDF;
-
-typedef struct {
 	int nid;
 	union {
 #if HAVE_PKCS5_PBKDF2_HMAC

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1475,7 +1475,11 @@ static const char *auxL_pusherror(lua_State *L, int error, const char *fun) {
 		if (!ERR_peek_error())
 			return lua_pushliteral(L, "oops: no OpenSSL errors set");
 
+#if OPENSSL_PREREQ(3,0,0)
+		code = ERR_get_error_all(&path, &line, NULL, NULL, NULL);
+#else
 		code = ERR_get_error_line(&path, &line);
+#endif
 
 		if ((file = strrchr(path, '/'))) {
 			++file;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2846,8 +2846,13 @@ typedef const CRYPTO_EX_DATA const_CRYPTO_EX_DATA;
 typedef CRYPTO_EX_DATA const_CRYPTO_EX_DATA;
 #endif
 
+#if OPENSSL_PREREQ(3,0,0)
+/* the function signature was fixed in version 3.0.0 */
+static int ex_ondup(CRYPTO_EX_DATA *to NOTUSED, const_CRYPTO_EX_DATA *from NOTUSED, void **from_d, int idx NOTUSED, long argl NOTUSED, void *argp NOTUSED) {
+#else
 static int ex_ondup(CRYPTO_EX_DATA *to NOTUSED, const_CRYPTO_EX_DATA *from NOTUSED, void *from_d, int idx NOTUSED, long argl NOTUSED, void *argp NOTUSED) {
-	struct ex_data **data = from_d;
+#endif
+	struct ex_data **data = (struct ex_data **)from_d;
 
 	if (*data)
 		(*data)->refs++;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3920,10 +3920,10 @@ static int bn_generatePrime(lua_State *L) {
 
 static int bn_isPrime(lua_State *L) {
 	BIGNUM *bn = checksimple(L, 1, BIGNUM_CLASS);
+	int nchecks = luaL_optinteger(L, 2, BN_prime_checks);
 #if OPENSSL_PREREQ(3,0,0)
 	int res = BN_check_prime(bn, getctx(L), NULL);
 #else
-	int nchecks = luaL_optinteger(L, 2, BN_prime_checks);
 	int res = BN_is_prime_ex(bn, nchecks, getctx(L), NULL);
 #endif
 


### PR DESCRIPTION
Hi there - I took a crack at updating this Lua module to work with OpenSSL 3.0.0 (issue #195), by trying to make the EVP_KDF-emulating functions closer match the OpenSSL 3.0.0 signatures.

I'm very welcome to feedback on this, there's one area where I'm not sure if I'm doing the right thing or not -

Previously, when using EVP_KDF_ctrl with `EVP_KDF_CTRL_SET_MD` - that uses some opaque message digest type. It looks like in OpenSSL 3.0.0, if youset the digest they expect a printable string. I'm unsure if `mk_checkdigest` is just taking a regular printable string and converting it to that custom type?

I'm also not super-stoked about OpenSSL adding this new `OSSL_PARAM` type and requiring its usage - this resulted in having a whole lot of `#if` directives in the `kdf_derive` function. The only other way I see getting around that would be actually defining the `OSSL_PARAM` type and writing those `construct` functions, then write a replacement `EVP_KDF_CTX_set_params` function that iterates through the params and calls `EVP_KDF_ctrl` with the appropriate arguments.

There's a good number of deprecation warnings, but as far as I can tell it works correctly. But could/should probably get more eyes on it and tested.